### PR TITLE
Command-line parameters check, Ruby 3.0 tests, libemf2svg 1.7.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os: [ ubuntu-18.04, ubuntu-latest, windows-latest, macos-latest ]
         ruby-version: [ '2.7', '3.0', '3.1' ]
@@ -45,23 +45,18 @@ jobs:
           - os: ubuntu-18.04
             platform: any
             ruby-version: '2.7'
-            file: 'skip'
           - os: ubuntu-18.04
             platform: x86_64-linux
             ruby-version: '2.7'
-            file: 'ELF 64-bit LSB shared object, x86-64'
           - os: windows-latest
             platform: x64-mingw32
             ruby-version: '2.7'
-            file: 'skip'
           - os: windows-latest
             platform: x64-mingw-ucrt
             ruby-version: '3.1'
-            file: 'skip'
           - os: macos-latest
             platform: x86_64-darwin
             ruby-version: '2.7'
-            file: 'Mach-O 64-bit dynamically linked shared library x86_64'
     steps:
     - uses: actions/checkout@v3
 
@@ -84,48 +79,78 @@ jobs:
         name: pkg
         path: pkg/*.gem
 
-    - name: Install gem
-      run: gem install -b pkg/emf2svg-*.gem
-
-    - name: Test conversion
-      run: |
-        ruby -remf2svg -e "puts File.write('output.svg', Emf2svg.from_file('spec/examples/image1.emf'), mode: 'wb')"
-
-    - name: Check file format
-      if: matrix.file != 'skip'
-      run: file $(ls pkg/*/lib/emf2svg/libemf2svg.*) | grep "${{ matrix.file }}"
-
-  test-build:
-    needs: build
+  cross-build:
+    name: build ${{ matrix.os }}, ${{ matrix.ruby-version }}, ${{ matrix.platform }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest
-            platform: any
-            ruby-version: '2.7'
-          - os: windows-latest
-            platform: any
+            platform: aarch64-linux
             ruby-version: '2.7'
           - os: macos-latest
-            platform: any
+            platform: arm64-darwin
             ruby-version: '2.7'
-          - os: ubuntu-18.04
-            platform: x86_64-linux
-            ruby-version: '2.7'
-          - os: ubuntu-latest
-            platform: x86_64-linux
-            ruby-version: '2.7'
-          - os: windows-latest
-            platform: x64-mingw32
-            ruby-version: '2.7'
-          - os: windows-latest
-            platform: x64-mingw-ucrt
-            ruby-version: '3.1'
-          - os: macos-latest
-            platform: x86_64-darwin
-            ruby-version: '2.7'
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install Ubuntu packages
+      if: startsWith(matrix.os, 'ubuntu')
+      run: |
+        sudo apt-get update
+        sudo apt-get install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu binutils-aarch64-linux-gnu gperf
+
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: true
+
+    - name: Build native extension
+      run: bundle exec rake gem:native:${{ matrix.platform }}
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: pkg
+        path: pkg/*.gem
+
+  test-build:
+    needs: [ build, cross-build ]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-18.04, ubuntu-latest, windows-latest, macos-latest ]
+        ruby-version: [ '2.7', '3.0', '3.1' ]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+
+    - uses: actions/download-artifact@v2
+      with:
+        name: pkg
+        path: pkg
+
+    - name: Install binary gem
+      run: gem install -b pkg/emf2svg-$(ruby -I lib -r emf2svg/version -e "puts Emf2svg::VERSION")-$(ruby -e "puts RUBY_PLATFORM.sub(/darwin\d{2}$/, 'darwin')").gem
+# MacOS with have something like arm64-darwin19, others just aarch64-linux
+    - name: Test conversion
+      run: |
+        ruby -remf2svg -e "puts File.write('output.svg', Emf2svg.from_file('spec/examples/image1.emf'), mode: 'wb')"
+
+  test-build-any:
+    needs: [ build, cross-build ]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-18.04, ubuntu-latest, windows-latest, macos-latest ]
+        ruby-version: [ '2.7', '3.0', '3.1' ]
 
     steps:
     - uses: actions/checkout@v2
@@ -146,73 +171,8 @@ jobs:
         sudo apt-get install gperf
 
     - name: Install native gem
-      if: matrix.platform == 'any'
       run: gem install -b pkg/emf2svg-$(ruby -I lib -r emf2svg/version -e "puts Emf2svg::VERSION").gem
-
-    - name: Install binary gem
-      if: matrix.platform != 'any'
-      run: gem install -b pkg/emf2svg-*-${{ matrix.platform }}.gem
 
     - name: Test conversion
       run: |
         ruby -remf2svg -e "puts File.write('output.svg', Emf2svg.from_file('spec/examples/image1.emf'), mode: 'wb')"
-
-  cross:
-    name: build ${{ matrix.os }}, ${{ matrix.ruby-version }}, ${{ matrix.platform }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: ubuntu-latest
-            platform: aarch64-linux
-            ruby-version: '2.7'
-            file: 'ELF 64-bit LSB shared object, ARM aarch64'
-          - os: macos-latest
-            platform: arm64-darwin
-            ruby-version: '2.7'
-            file: 'Mach-O 64-bit dynamically linked shared library arm64'
-    steps:
-    - uses: actions/checkout@v3
-
-    - name: Install Ubuntu packages
-      if: startsWith(matrix.os, 'ubuntu')
-      run: |
-        sudo apt-get update
-        sudo apt-get install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu binutils-aarch64-linux-gnu gperf
-
-    - name: Setup MacOS environment
-      if: startsWith(matrix.os, 'macos')
-      run: |
-        echo 'BREW_HOME<<EOF' >> $GITHUB_ENV
-        brew --prefix >> $GITHUB_ENV
-        echo 'EOF' >> $GITHUB_ENV
-
-    - name: Install Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby-version }}
-        bundler-cache: true
-
-    - run: bundle exec rake gem:native:${{ matrix.platform }}
-
-    - uses: actions/upload-artifact@v2
-      with:
-        name: pkg
-        path: pkg/*.gem
-
-    - name: Install gem
-      run: gem install -b pkg/emf2svg-*-${{ matrix.platform }}.gem
-
-    - name: Check file format
-      run: file $(ls pkg/*/lib/emf2svg/libemf2svg.*) | grep "${{ matrix.file }}"
-
-    - name: Checkout shell test framework
-      uses: actions/checkout@v3
-      with:
-        repository: kward/shunit2
-        path: tests/shunit2
-        fetch-depth: 1
-
-    - name: Run additional tests
-      run: ${{ env.BREW_HOME }}/bin/bash tests/lcheck.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         os: [ ubuntu-18.04, ubuntu-latest, windows-latest, macos-latest ]
         ruby-version: [ '2.7', '3.0', '3.1' ]
@@ -202,7 +202,7 @@ jobs:
         path: pkg/*.gem
 
     - name: Install gem
-      run: gem install -b pkg/emf2svg-*.gem
+      run: gem install -b pkg/emf2svg-*-${{ matrix.platform }}.gem
 
     - name: Check file format
       run: file $(ls pkg/*/lib/emf2svg/libemf2svg.*) | grep "${{ matrix.file }}"
@@ -214,5 +214,5 @@ jobs:
         path: tests/shunit2
         fetch-depth: 1
 
-#    - name: Run additional tests
-#      run: ${{ env.BREW_HOME }}/bin/bash tests/lcheck.sh
+    - name: Run additional tests
+      run: ${{ env.BREW_HOME }}/bin/bash tests/lcheck.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,10 +15,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-18.04, ubuntu-latest, windows-latest, macos-latest ]
-        ruby-version: [ '2.7' ]
-        include:
-          - os: windows-latest
-            ruby-version: '3.1'
+        ruby-version: [ '2.7', '3.0', '3.1' ]
+
     steps:
     - uses: actions/checkout@v3
 
@@ -67,7 +65,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - uses: ruby/setup-ruby@v1
+    - name: Setup Ruby
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true
@@ -176,13 +175,21 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Install packages
-      if: matrix.os == 'ubuntu-latest'
+    - name: Install Ubuntu packages
+      if: startsWith(matrix.os, 'ubuntu')
       run: |
         sudo apt-get update
         sudo apt-get install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu binutils-aarch64-linux-gnu gperf
 
-    - uses: ruby/setup-ruby@v1
+    - name: Setup MacOS environment
+      if: startsWith(matrix.os, 'macos')
+      run: |
+        echo 'BREW_HOME<<EOF' >> $GITHUB_ENV
+        brew --prefix >> $GITHUB_ENV
+        echo 'EOF' >> $GITHUB_ENV
+
+    - name: Install Ruby
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true
@@ -199,3 +206,13 @@ jobs:
 
     - name: Check file format
       run: file $(ls pkg/*/lib/emf2svg/libemf2svg.*) | grep "${{ matrix.file }}"
+
+    - name: Checkout shell test framework
+      uses: actions/checkout@v3
+      with:
+        repository: kward/shunit2
+        path: tests/shunit2
+        fetch-depth: 1
+
+#    - name: Run additional tests
+#      run: ${{ env.BREW_HOME }}/bin/bash tests/lcheck.sh

--- a/README.adoc
+++ b/README.adoc
@@ -54,9 +54,13 @@ There are two ways to provide EMF data to `emf2svg`.
 ----
 require "emf2svg"
 
-data = Emf2svg.from_file("example.emf")
+data = Emf2svg.from_file("example.emf", 800, 600)
 File.write("output.svg", data, mode: "wb")
 ----
+800, 600 - optional width and height of the bounding rectangle for svg file
+The image will be scaled to fit into this rectangle
+These parameters are optional. If skipped or set to 0 SVG image will have the
+same size as EMF (in pixels)
 ====
 
 === Loading binary data
@@ -71,9 +75,13 @@ File.write("output.svg", data, mode: "wb")
 require "emf2svg"
 
 emf_content = File.read("example.emf", mode: "rb")
-svg_data = Emf2svg.from_binary_string(emf_content)
+svg_data = Emf2svg.from_binary_string(emf_content, 800, 600)
 File.write("output.svg", svg_data, mode: "wb")
 ----
+800, 600 - optional width and height of the bounding rectangle for svg file
+The image will be scaled to fit into this rectangle
+These parameters are optional. If skipped or set to 0 SVG image will have the
+same size as EMF (in pixels)
 ====
 
 

--- a/Rakefile
+++ b/Rakefile
@@ -14,6 +14,7 @@ task default: %i[spec rubocop]
 task :compile do
   require_relative "ext/extconf"
 end
+
 task spec: :compile
 
 desc "Build install-compilation gem"

--- a/bin/emf2svg
+++ b/bin/emf2svg
@@ -1,8 +1,38 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require "bundler/setup"
 require "emf2svg"
 
-svg = Emf2svg.from_file(ARGV[0])
-File.write(ARGV[1], svg, mode: "wb")
+def print_usage
+  usage = %{Usage: emf2svg <input> <output> [<width>] [<height>]
+  <input>  -- emf file to convert
+  <output> -- svg file to save
+  <width>  -- svg image width, defaults to source width in px if not set or 0
+  <height> -- svg image height, defaults to source height in px if not set or 0
+  Note: width and height specify bounding rectangle, the image will be scaled
+        propotionally to fit into it.
+}
+  puts usage
+end
+
+def tint(pos)
+  ARGV.size > pos ? Integer(ARGV[pos]) : 0
+rescue ArgumentError, TypeError => e
+  puts "ERROR: Failed to convert #{ARGV[pos]} to integer: #{e.message}"
+  print_usage
+  exit 1
+end
+
+if ARGV.size < 2 || ARGV.size > 4 || ARGV[0].casecmp("help").zero?
+  print_usage
+  exit 0
+end
+
+begin
+  svg = Emf2svg.from_file(ARGV[0], tint(2), tint(3))
+  File.write(ARGV[1], svg, mode: "wb")
+rescue StandardError => e
+  puts "ERROR: Failed to process #{ARGV[0]}: #{e.message}"
+  print_usage
+  exit 1
+end

--- a/emf2svg.gemspec
+++ b/emf2svg.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Ribose"]
   spec.email         = ["open.source@ribose.com"]
 
-  spec.summary       = "Ruby interface to libemf2svg."
+  spec.summary       = "EMF to SVG conversion in Ruby."
   spec.homepage      = "https://github.com/metanorma/emf2svg-ruby"
   spec.license       = "BSD-2-Clause"
   spec.required_ruby_version = ">= 2.6.0"

--- a/exe/emf2svg
+++ b/exe/emf2svg
@@ -4,11 +4,10 @@
 require "emf2svg"
 
 def print_usage
-  usage = %{
-    Usage: emf2svg <input> <output>
-        <input>  -- emf file to convert
-        <output> -- svg file to save
-    }
+  usage = %{Usage: emf2svg <input> <output>
+  <input>  -- emf file to convert
+  <output> -- svg file to save
+}
   puts usage
 end
 
@@ -21,6 +20,6 @@ begin
   svg = Emf2svg.from_file(ARGV[0])
   File.write(ARGV[1], svg, mode: "wb")
 rescue StandardError => e
-  puts "Failed to process #{ARGV[0]}: #{e.message}"
+  puts "ERROR: Failed to process #{ARGV[0]}: #{e.message}"
   print_usage
 end

--- a/exe/emf2svg
+++ b/exe/emf2svg
@@ -4,22 +4,35 @@
 require "emf2svg"
 
 def print_usage
-  usage = %{Usage: emf2svg <input> <output>
+  usage = %{Usage: emf2svg <input> <output> [<width>] [<height>]
   <input>  -- emf file to convert
   <output> -- svg file to save
+  <width>  -- svg image width, defaults to source width in px if not set or 0
+  <height> -- svg image height, defaults to source height in px if not set or 0
+  Note: width and height specify bounding rectangle, the image will be scaled
+        propotionally to fit into it.
 }
   puts usage
 end
 
-if ARGV.size != 2 || ARGV[0].casecmp("help").zero?
+def tint(pos)
+  ARGV.size > pos ? Integer(ARGV[pos]) : 0
+rescue ArgumentError, TypeError => e
+  puts "ERROR: Failed to convert #{ARGV[pos]} to integer: #{e.message}"
+  print_usage
+  exit 1
+end
+
+if ARGV.size < 2 || ARGV.size > 4 || ARGV[0].casecmp("help").zero?
   print_usage
   exit 0
 end
 
 begin
-  svg = Emf2svg.from_file(ARGV[0])
+  svg = Emf2svg.from_file(ARGV[0], tint(2), tint(3))
   File.write(ARGV[1], svg, mode: "wb")
 rescue StandardError => e
   puts "ERROR: Failed to process #{ARGV[0]}: #{e.message}"
   print_usage
+  exit 1
 end

--- a/exe/emf2svg
+++ b/exe/emf2svg
@@ -3,5 +3,24 @@
 
 require "emf2svg"
 
-svg = Emf2svg.from_file(ARGV[0])
-File.write(ARGV[1], svg, mode: "wb")
+def print_usage
+  usage = %{
+    Usage: emf2svg <input> <output>
+        <input>  -- emf file to convert
+        <output> -- svg file to save
+    }
+  puts usage
+end
+
+if ARGV.size != 2 || ARGV[0].casecmp("help").zero?
+  print_usage
+  exit 0
+end
+
+begin
+  svg = Emf2svg.from_file(ARGV[0])
+  File.write(ARGV[1], svg, mode: "wb")
+rescue StandardError => e
+  puts "Failed to process #{ARGV[0]}: #{e.message}"
+  print_usage
+end

--- a/lib/emf2svg.rb
+++ b/lib/emf2svg.rb
@@ -39,17 +39,18 @@ module Emf2svg
                   :int
 
   class << self
-    def from_file(path)
+    def from_file(path, width = 0, height = 0)
       content = File.read(path, mode: "rb")
-      from_binary_string(content)
+      from_binary_string(content, width, height)
     end
 
-    def from_binary_string(content)
+    def from_binary_string(content, width = 0, height = 0)
       svg_out = FFI::MemoryPointer.new(:pointer)
       svg_out_len = FFI::MemoryPointer.new(:pointer)
       content_ptr = FFI::MemoryPointer.from_string(content)
 
-      ret = emf2svg(content_ptr, content.size, svg_out, svg_out_len, options)
+      opt = options(width, height)
+      ret = emf2svg(content_ptr, content.size, svg_out, svg_out_len, opt)
       raise Error, "emf2svg failed with error code: #{ret}" unless ret == 1
 
       svg_out.read_pointer.read_bytes(svg_out_len.read_int)
@@ -57,13 +58,13 @@ module Emf2svg
 
     private
 
-    def options
+    def options(width, height)
       GeneratorOptions.new.tap do |opts|
         opts[:verbose] = false
         opts[:emfplus] = true
         opts[:svgDelimiter] = true
-        opts[:imgHeight] = 0
-        opts[:imgWidth] = 0
+        opts[:imgHeight] = height
+        opts[:imgWidth] = width
       end
     end
   end

--- a/lib/emf2svg/recipe.rb
+++ b/lib/emf2svg/recipe.rb
@@ -8,11 +8,11 @@ module Emf2svg
     ROOT = Pathname.new(File.expand_path("../..", __dir__))
 
     def initialize
-      super("libemf2svg", "1.7.0")
+      super("libemf2svg", LIBEMF2SVG_VERSION)
 
       @files << {
-        url: "https://github.com/metanorma/libemf2svg/releases/download/v1.7.0/libemf2svg.tar.gz",
-        sha256: "a87a02510f87ed4510a3426fa8636b340e26d96f25edf63c3ba465e7e9d7e2eb", # rubocop:disable Layout/LineLength
+        url: "https://github.com/metanorma/libemf2svg/releases/download/v#{LIBEMF2SVG_VERSION}/libemf2svg.tar.gz",
+        sha256: "c65f25040a351d18beb5172609a55d034245f85a1152d7f294780c6cc155d876", # rubocop:disable Layout/LineLength
       }
 
       @target = ROOT.join(@target).to_s

--- a/lib/emf2svg/recipe.rb
+++ b/lib/emf2svg/recipe.rb
@@ -2,6 +2,7 @@ require "rbconfig"
 require "mini_portile2"
 require "pathname"
 require "tmpdir"
+require_relative "version"
 
 module Emf2svg
   class Recipe < MiniPortileCMake
@@ -50,7 +51,7 @@ module Emf2svg
 
     def target_platform
       @target_platform ||=
-        case ENV["target_platform"]
+        case ENV.fetch("target_platform", nil)
         when /\A(arm64|aarch64).*(darwin|macos|osx)/
           "arm64-darwin"
         when /\Ax86_64.*(darwin|macos|osx)/
@@ -58,7 +59,7 @@ module Emf2svg
         when /\A(arm64|aarch64).*linux/
           "aarch64-linux"
         else
-          ENV["target_platform"] || host_platform
+          ENV.fetch("target_platform", host_platform)
         end
     end
 
@@ -128,6 +129,7 @@ module Emf2svg
     end
 
     def execute(action, command, command_opts = {})
+      puts("=== execute : #{action}, #{command} ===")
       super(action, command, command_opts.merge(debug: true))
     end
 

--- a/lib/emf2svg/recipe.rb
+++ b/lib/emf2svg/recipe.rb
@@ -2,6 +2,7 @@ require "rbconfig"
 require "mini_portile2"
 require "pathname"
 require "tmpdir"
+require "open3"
 require_relative "version"
 
 module Emf2svg
@@ -27,6 +28,100 @@ module Emf2svg
     def cook
       super
       FileUtils.touch(checkpoint)
+    end
+
+    def windows_native?
+      MiniPortile.windows? && target_triplet.eql?("x64-mingw-static")
+    end
+
+    def drop_target_triplet?
+      windows_native? || host_platform.eql?(target_platform)
+    end
+
+    def checkpoint
+      File.join(@target, "#{name}-#{version}-#{target_platform}.installed")
+    end
+
+    def configure_defaults
+      opts = []
+
+      opts << "-DCMAKE_BUILD_TYPE=Release"
+      opts << "-DLONLY=ON"
+
+      unless target_triplet.nil? || drop_target_triplet?
+        opts << "-DVCPKG_TARGET_TRIPLET=#{target_triplet}"
+      end
+
+      opts << "-DCMAKE_TOOLCHAIN_FILE=vcpkg/scripts/buildsystems/vcpkg.cmake"
+
+      opts
+    end
+
+    def compile
+      execute("compile", "#{make_cmd} --target emf2svg")
+    end
+
+    def make_cmd
+      "cmake --build #{File.expand_path(work_path)} --config Release"
+    end
+
+    def lb_to_verify
+      pt = if MiniPortile.windows?
+             "emf2svg.dll"
+           else
+             "libemf2svg.{so,dylib}"
+           end
+      @lb_to_verify ||= Dir.glob(ROOT.join("lib", "emf2svg", pt))
+    end
+
+    def verify_libs
+      lb_to_verify.each do |l|
+        out, st = Open3.capture2("file #{l}")
+        raise "Failed to query file #{l}: #{out}" unless st.exitstatus.zero?
+
+        if out.include?(target_format)
+          message("Verifying #{l} ... OK\n")
+        else
+          raise "Invalid file format '#{out}', '#{@target_format}' expected"
+        end
+      end
+    end
+
+    def install
+      libs = if MiniPortile.windows?
+               Dir.glob(File.join(work_path, "Release", "*.dll"))
+             else
+               Dir.glob(File.join(work_path, "libemf2svg.{so,dylib}"))
+                 .grep(/\/(?:lib)?[a-zA-Z0-9\-]+\.(?:so|dylib)$/)
+             end
+      FileUtils.cp_r(libs, ROOT.join("lib", "emf2svg"), verbose: true)
+
+      verify_libs unless target_format.eql?("skip")
+    end
+
+    def execute(action, command, command_opts = {})
+      super(action, command, command_opts.merge(debug: false))
+    end
+
+    def message(text)
+      return super unless text.start_with?("\rDownloading")
+
+      match = text.match(/(\rDownloading .*)\(\s*\d+%\)/)
+      pattern = match ? match[1] : text
+      return if @printed[pattern]
+
+      @printed[pattern] = true
+      super
+    end
+
+    private
+
+    def tmp_path
+      @tmp_path ||= Dir.mktmpdir
+    end
+
+    def port_path
+      "port"
     end
 
     # rubocop:disable Metrics/MethodLength
@@ -78,80 +173,25 @@ module Emf2svg
           "x64-mingw-static"
         end
     end
+
+    def target_format
+      @target_format ||=
+        case target_platform
+        when "arm64-darwin"
+          "Mach-O 64-bit dynamically linked shared library arm64"
+        when "x86_64-darwin"
+          "Mach-O 64-bit dynamically linked shared library x86_64"
+        when "aarch64-linux"
+          "ELF 64-bit LSB shared object, ARM aarch64"
+        when "x86_64-linux"
+          "ELF 64-bit LSB shared object, x86-64"
+        when /\Ax64-mingw(32|-ucrt)/
+          "PE32+ executable (DLL) (console) x86-64, for MS Windows"
+        else
+          "skip"
+        end
+    end
     # rubocop:enable Metrics/CyclomaticComplexity
     # rubocop:enable Metrics/MethodLength
-
-    def windows_native?
-      MiniPortile.windows? && target_triplet.eql?("x64-mingw-static")
-    end
-
-    def drop_target_triplet?
-      windows_native? || host_platform.eql?(target_platform)
-    end
-
-    def checkpoint
-      File.join(@target, "#{name}-#{version}-#{target_platform}.installed")
-    end
-
-    def configure_defaults
-      opts = []
-
-      opts << "-DCMAKE_BUILD_TYPE=Release"
-      opts << "-DLONLY=ON"
-
-      unless target_triplet.nil? || drop_target_triplet?
-        opts << "-DVCPKG_TARGET_TRIPLET=#{target_triplet}"
-      end
-
-      opts << "-DCMAKE_TOOLCHAIN_FILE=vcpkg/scripts/buildsystems/vcpkg.cmake"
-
-      opts
-    end
-
-    def compile
-      execute("compile", "#{make_cmd} --target emf2svg")
-    end
-
-    def make_cmd
-      "cmake --build #{File.expand_path(work_path)} --config Release"
-    end
-
-    def install
-      message("Called install\n")
-      libs = if MiniPortile.windows?
-               Dir.glob(File.join(work_path, "Release", "*.dll"))
-             else
-               Dir.glob(File.join(work_path, "libemf2svg.{so,dylib}"))
-                 .grep(/\/(?:lib)?[a-zA-Z0-9\-]+\.(?:so|dylib)$/)
-             end
-
-      FileUtils.cp_r(libs, ROOT.join("lib", "emf2svg"), verbose: true)
-    end
-
-    def execute(action, command, command_opts = {})
-      puts("=== execute : #{action}, #{command} ===")
-      super(action, command, command_opts.merge(debug: true))
-    end
-
-    def message(text)
-      return super unless text.start_with?("\rDownloading")
-
-      match = text.match(/(\rDownloading .*)\(\s*\d+%\)/)
-      pattern = match ? match[1] : text
-      return if @printed[pattern]
-
-      @printed[pattern] = true
-      super
-    end
-
-    private
-
-    def tmp_path
-      @tmp_path ||= Dir.mktmpdir
-    end
-
-    def port_path
-      "port"
-    end
   end
 end

--- a/lib/emf2svg/version.rb
+++ b/lib/emf2svg/version.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
 module Emf2svg
-  VERSION = "1.4.1"
+  VERSION = "1.4.2"
+  LIBEMF2SVG_VERSION = "1.7.1"
 end

--- a/spec/emf2svg_spec.rb
+++ b/spec/emf2svg_spec.rb
@@ -7,12 +7,23 @@ RSpec.describe Emf2svg do
 
   let(:example_file) { File.expand_path("examples/image1.emf", __dir__) }
 
-  it "converts from file" do
+  it "converts from file unscaled" do
     expect(described_class.from_file(example_file).size).to eq 39849
   end
 
-  it "converts from string" do
+  it "converts from string unscaled" do
     string = File.read(example_file, mode: "rb")
     expect(described_class.from_binary_string(string).size).to eq 39849
+  end
+
+  it "converts from file scaled" do
+    converted = described_class.from_file(example_file, 800, 600)
+    expect(converted.size).to eq 39607
+  end
+
+  it "converts from string scaled" do
+    string = File.read(example_file, mode: "rb")
+    converted = described_class.from_binary_string(string, 800, 600)
+    expect(converted.size).to eq 39607
   end
 end


### PR DESCRIPTION
- libemf2svg 1.7.1 (fixes issues mentioned at https://github.com/metanorma/iso-15926-6/pull/1#issuecomment-1103680097)
- Command-line parameters check (#30)
- CI scripts refactoring, including Ruby 3.0 tests (#27)
- libemf2svg width and height parameters for target image exposed to Ruby